### PR TITLE
Modernize CI workflows and bump Node floor to 22

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
   node_version:
     description: The Node.js version.
     required: false
-    default: '16'
+    default: '22'
   registry_url:
     description: The Node.js package registry URL.
     required: false
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v5
       with:
         cache: npm
         node-version: ${{ inputs.node_version }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,16 +12,16 @@ on:
 
 jobs:
   fix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true
@@ -34,7 +34,7 @@ jobs:
       - name: Format
         run: npm run format
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Run format
           commit_user_name: ${{ secrets.GIT_USER_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build
@@ -19,11 +19,11 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Setup
         uses: ./.github/actions/setup
       - name: Lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,51 +8,81 @@ on:
 
 jobs:
   npm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup
-        uses: ./.github/actions/setup
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
         with:
-          node_version: '14'
-      - name: Publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          access: public
-          token: ${{ secrets.NPM_TOKEN }}
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+      - name: Check version
+        id: version
+        shell: bash
+        run: |
+          name="$(jq -r '.name' package.json)"
+          current="$(jq -r '.version' package.json)"
+          published="$(npm view "${name}@${current}" version 2>/dev/null || true)"
+          {
+            echo "name=${name}"
+            echo "current=${current}"
+            echo "published=${published}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Publish ${{ steps.version.outputs.name }}@${{ steps.version.outputs.current }}
+        if: ${{ steps.version.outputs.published != steps.version.outputs.current }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   github:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Publish
-        uses: JS-DevTools/npm-publish@v1
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
         with:
-          access: public
-          token: ${{ secrets.GITHUB_TOKEN }}
-          registry: https://npm.pkg.github.com
+          node-version: '22'
+          registry-url: https://npm.pkg.github.com
+          scope: '@${{ github.repository_owner }}'
+      - name: Check version
+        id: version
+        shell: bash
+        run: |
+          name="$(jq -r '.name' package.json)"
+          current="$(jq -r '.version' package.json)"
+          published="$(npm view "${name}@${current}" version 2>/dev/null || true)"
+          {
+            echo "name=${name}"
+            echo "current=${current}"
+            echo "published=${published}"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Publish ${{ steps.version.outputs.name }}@${{ steps.version.outputs.current }}
+        if: ${{ steps.version.outputs.published != steps.version.outputs.current }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_TOKEN }}
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
-          git-user-signingkey: true
-          git-commit-gpgsign: true
-          git-committer-name: ${{ secrets.GIT_USER_NAME }}
-          git-committer-email: ${{ secrets.GIT_USER_EMAIL }}
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_committer_name: ${{ secrets.GIT_USER_NAME }}
+          git_committer_email: ${{ secrets.GIT_USER_EMAIL }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Setup
         uses: ./.github/actions/setup
@@ -61,7 +91,7 @@ jobs:
         env:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
       - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.GH_TOKEN }}
           publish_dir: build

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup Git config
@@ -31,7 +31,7 @@ jobs:
           git config user.name "$GIT_USER_NAME"
           git config user.email "$GIT_USER_EMAIL"
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           git_user_signingkey: true
           git_commit_gpgsign: true

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+
+### Changed
+
+- Modernized GitHub Actions workflows so current runners can schedule them:
+  `ubuntu-20.04` runners to `ubuntu-latest`, `actions/checkout` v2 to v5,
+  `actions/setup-node` v2 to v5, `crazy-max/ghaction-import-gpg` v3/v4 to v7,
+  `stefanzweifel/git-auto-commit-action` v4 to v7, and
+  `peaceiris/actions-gh-pages` v3 to v4.
+- Replaced the deprecated `JS-DevTools/npm-publish` action with a plain
+  `npm publish` step guarded by a published-version check.
+- Fixed the kebab-case GPG inputs in the gh-pages job (e.g. `gpg-private-key`),
+  which `ghaction-import-gpg` silently ignores; they are now snake_case so the
+  signing key actually imports.
+- Bumped the Node floor to 22 (`engines.node`, `.nvmrc`, and the setup action
+  default); validated that the Docusaurus build still succeeds on Node 22.

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "postformat": "prettier --write --ignore-path .gitignore 'docs/**/*.(md)'"
   },
   "engines": {
-    "node": ">=14.15.0",
-    "npm": ">= 8.1.0"
+    "node": ">=22.0.0"
   },
   "overrides": {
     "@docusaurus/core": {


### PR DESCRIPTION
No dependency migration needed (no @meltwater packages present). Upgrade GitHub Actions so current runners can schedule the jobs and remove deprecated actions:

- ubuntu-20.04 -> ubuntu-latest across all workflows
- actions/checkout v2 -> v5, actions/setup-node v2 -> v5
- crazy-max/ghaction-import-gpg v3/v4 -> v7
- stefanzweifel/git-auto-commit-action v4 -> v7
- peaceiris/actions-gh-pages v3 -> v4
- replace deprecated JS-DevTools/npm-publish with a plain npm publish step guarded by a published-version check (npm + GitHub Packages)
- fix kebab-case GPG inputs in the gh-pages job (silently ignored by ghaction-import-gpg) so the signing key actually imports

Bump engines.node to >=22.0.0 (drop npm engine), .nvmrc to 22, and the setup action default node_version to 22. Verified the Docusaurus build still succeeds on Node 22.